### PR TITLE
Add support for Valet Linux Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A PHP Laravel Valet status indicator and manager extension (GNOME Panel Applet) 
 
 ## Prerequisite
 
-- Properly installed and running [Laravel Valet Linux](https://cpriego.github.io/valet-linux/).
+- Properly installed and running [Laravel Valet Linux](https://cpriego.github.io/valet-linux/) or [Valet Linux Plus](https://github.com/valet-linux-plus/valet-linux-plus).
 
 ## Installation
 

--- a/utils.js
+++ b/utils.js
@@ -23,7 +23,13 @@ export function phpVersion() {
     const res = safeSpawn('/bin/bash -c "php -v | grep -Po \'PHP\\s+\\d+.\\d+(?:(.\\d+))?\'"')
 
     if (res[3] == 0) {
-        return String.fromCharCode(...res[1]).replace(/\n$/, '')
+        let output = '';
+        try {
+            output = new TextDecoder().decode(res[1]);
+        } catch (e) {
+            output = String.fromCharCode(...res[1]);
+        }
+        return output.replace(/\n$/, '')
     }
 
     return null
@@ -38,14 +44,20 @@ export function phpList() {
     const res = safeSpawn('ls /etc/php')
 
     if (res[3] == 0) {
-        return String.fromCharCode(...res[1]).split('\n').filter(item => !!item).reverse()
+        let output = '';
+        try {
+            output = new TextDecoder().decode(res[1]);
+        } catch (e) {
+            output = String.fromCharCode(...res[1]);
+        }
+        return output.split('\n').filter(item => !!item).reverse()
     }
 
     return []
 }
 
 /**
- * Retrieves and parses the output of `valet list`.
+ * Retrieves and parses the output of `valet links`.
  *
  * @returns {Array<{site: string, ssl: boolean, url: string, path: string, php: string}>}
  */
@@ -53,20 +65,51 @@ export function valetList() {
     const res = safeSpawn('/bin/bash -c "valet links"')
 
     if (res[3] == 0) {
-        const lines = String.fromCharCode(...res[1]).split('\n').filter(item => !!item)
+        let output = '';
+        try {
+            output = new TextDecoder().decode(res[1]);
+        } catch (e) {
+            output = String.fromCharCode(...res[1]);
+        }
+
+        // Remove ANSI color codes
+        output = output.replace(/\x1B\[[0-9;]*[mGKHJK]/g, '');
+
+        const lines = output.split('\n').filter(item => !!item)
 
         return lines
-            .filter(line => line.startsWith('|') && !line.startsWith('| Site') && !line.startsWith('+'))
+            .map(line => line.trim())
+            .filter(line => line.startsWith('|') && !line.startsWith('| Site') && !line.startsWith('| URL') && !line.startsWith('+'))
             .map(line => {
                 const parts = line.split('|').map(item => item.trim()).slice(1, -1)
-                return {
-                    site: parts[0],
-                    ssl: !!parts[1],
-                    url: parts[2],
-                    path: parts[3],
-                    php: parts[4]
+
+                if (parts.length === 3) {
+                    // Valet Linux Plus format: | URL | SSL | Path |
+                    const url = parts[0];
+                    const site = url.replace(/^https?:\/\//, '').replace(/\.[^/]+$/, '');
+                    return {
+                        site: site,
+                        ssl: !!parts[1],
+                        url: url,
+                        path: parts[2],
+                        php: 'Default'
+                    }
                 }
+
+                if (parts.length >= 5) {
+                    // Valet Linux format: | Site | SSL | URL | Path | PHP |
+                    return {
+                        site: parts[0],
+                        ssl: !!parts[1],
+                        url: parts[2],
+                        path: parts[3],
+                        php: parts[4]
+                    }
+                }
+
+                return null;
             })
+            .filter(item => item !== null)
     }
 
     return []
@@ -81,7 +124,17 @@ export function valetStatus() {
     const res = safeSpawn('/bin/bash -c "valet --version && valet status"')
 
     if (res[3] == 0) {
-        return String.fromCharCode(...res[1]).split('\n').filter(item => !!item)
+        let output = '';
+        try {
+            output = new TextDecoder().decode(res[1]);
+        } catch (e) {
+            output = String.fromCharCode(...res[1]);
+        }
+
+        // Remove ANSI color codes
+        output = output.replace(/\x1B\[[0-9;]*[mGKHJK]/g, '');
+
+        return output.split('\n').filter(item => !!item)
     }
 
     return []


### PR DESCRIPTION
This PR adds support for Valet Linux Plus by handling its 3-column table output in `valet links`. It also improves the robustness of the parser by stripping ANSI escape codes and using `TextDecoder` for proper UTF-8 handling (e.g. for the SSL checkmark).